### PR TITLE
Switching PostgreSQL test component from raw schema execution to a migration-based approach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,16 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions
 of [keepachangelog.com](http://keepachangelog.com/).
 
-## Unreleased
+## 6.2.4 - 2026-01-03
+
+### Added
+
+- Added `pg2-migration` as a new dependency for migration support.
+
+### Changed
+
+- Updated PostgreSQL mock component to use migrations for database setup instead of raw schemas.
+- Bumped versions of multiple dependencies to their latest releases.
 
 ## 5.2.4 - 2025-02-01
 

--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
   :profiles {:dev {:plugins        [[com.github.clojure-lsp/lein-clojure-lsp "2.0.13"]
                                     [com.github.liquidz/antq "RELEASE"]]
 
-                   :resource-paths ^:replace ["test/resources"]
+                   :resource-paths ["test/resources"]
 
                    :test-paths     ^:replace ["test/unit" "test/integration" "test/helpers"]
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject net.clojars.macielti/common-test-clj "5.2.4"
+(defproject net.clojars.macielti/common-test-clj "6.2.4"
 
   :description "Common utilities for testing Clojure code"
 
@@ -7,23 +7,24 @@
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url  "https://www.eclipse.org/legal/epl-2.0/"}
 
-  :dependencies [[org.clojure/clojure "1.12.0"]
-                 [net.clojars.macielti/common-clj "43.74.74"]
-                 [org.testcontainers/postgresql "1.20.4"]
-                 [com.github.igrishaev/pg2-core "0.1.33"]
+  :dependencies [[org.clojure/clojure "1.12.4"]
+                 [net.clojars.macielti/common-clj "43.74.77"]
+                 [org.testcontainers/postgresql "1.21.4"]
+                 [com.github.igrishaev/pg2-core "0.1.41"]
                  [prismatic/schema-generators "0.1.5"]
-                 [org.clojure/tools.logging "1.3.0"]
-                 [org.clojure/test.check "1.1.1"]
+                 [org.clojure/tools.logging "1.3.1"]
+                 [org.clojure/test.check "1.1.3"]
                  [clojure.java-time "1.4.3"]
                  [prismatic/schema "1.4.1"]
-                 [integrant "0.13.1"]
-                 [migratus "1.6.3"]
-                 [diehard "0.11.12"]
+                 [integrant "1.0.1"]
+                 [migratus "1.6.4"]
+                 [diehard "0.12.0"]
+                 [com.github.igrishaev/pg2-migration "0.1.41"]
 
-                 [org.xerial/sqlite-jdbc "3.41.2.1"]
-                 [com.github.seancorfield/next.jdbc "1.3.994"]]
+                 [org.xerial/sqlite-jdbc "3.51.1.0"]
+                 [com.github.seancorfield/next.jdbc "1.3.1086"]]
 
-  :profiles {:dev {:plugins        [[com.github.clojure-lsp/lein-clojure-lsp "1.4.16"]
+  :profiles {:dev {:plugins        [[com.github.clojure-lsp/lein-clojure-lsp "2.0.13"]
                                     [com.github.liquidz/antq "RELEASE"]]
 
                    :resource-paths ^:replace ["test/resources"]
@@ -31,7 +32,7 @@
                    :test-paths     ^:replace ["test/unit" "test/integration" "test/helpers"]
 
                    :dependencies   [[hashp "0.2.2"]
-                                    [nubank/matcher-combinators "3.9.1"]]
+                                    [nubank/matcher-combinators "3.9.2"]]
 
                    :injections     [(require 'hashp.core)]
 

--- a/src/common_test_clj/component/postgresql_mock.clj
+++ b/src/common_test_clj/component/postgresql_mock.clj
@@ -3,25 +3,25 @@
             [diehard.core :as dh]
             [integrant.core :as ig]
             [pg.core :as pg]
-            [schema.core :as s])
+            [schema.core :as s]
+            [pg.migration.core :as migrations])
   (:import (org.pg.error PGError)
            (org.testcontainers.containers PostgreSQLContainer)))
 
 (defmethod ig/init-key ::postgresql-mock
-  [_ {:keys [schemas]}]
+  [_ {:keys [components]}]
   (log/info :starting ::postgresql-mock)
   (let [postgresql-container (doto (PostgreSQLContainer. "postgres:16-alpine") .start)
         postgresql-config {:host     (.getHost postgresql-container)
                            :port     (.getMappedPort postgresql-container PostgreSQLContainer/POSTGRESQL_PORT)
                            :user     (.getUsername postgresql-container)
                            :password (.getPassword postgresql-container)
-                           :database (.getDatabaseName postgresql-container)}]
+                           :database (.getDatabaseName postgresql-container)}
+        migrations-config (-> components :config :postgresql-migrations (merge postgresql-config))]
     (dh/with-retry {:retry-on    PGError
                     :delay-ms    2000
                     :max-retries 3}
-      (pg/with-connection [database-conn (pg/pool postgresql-config)]
-        (doseq [schema schemas]
-          (pg/execute database-conn schema))))
+                   (migrations/migrate-all migrations-config))
     (pg/pool postgresql-config)))
 
 (defmethod ig/halt-key! ::postgresql-mock
@@ -31,18 +31,17 @@
 
 (s/defn postgresql-pool-mock
   "Intended to be used for unit testing"
-  [schemas]
-  (let [postgresql-container (doto (PostgreSQLContainer. "postgres:16-alpine")
-                               .start)
+  [migrations-path]
+  (let [postgresql-container (doto (PostgreSQLContainer. "postgres:16-alpine") .start)
         postgresql-config {:host     (.getHost postgresql-container)
                            :port     (.getMappedPort postgresql-container PostgreSQLContainer/POSTGRESQL_PORT)
                            :user     (.getUsername postgresql-container)
                            :password (.getPassword postgresql-container)
-                           :database (.getDatabaseName postgresql-container)}]
+                           :database (.getDatabaseName postgresql-container)}
+        migrations-config (merge postgresql-config {:migrations-table :migrations
+                                                    :migrations-path  migrations-path})]
     (dh/with-retry {:retry-on    PGError
                     :delay-ms    2000
                     :max-retries 3}
-      (pg/with-connection [database-conn (pg/pool postgresql-config)]
-        (doseq [schema schemas]
-          (pg/execute database-conn schema))))
+                   (migrations/migrate-all migrations-config))
     (pg/pool postgresql-config)))

--- a/src/common_test_clj/component/postgresql_mock.clj
+++ b/src/common_test_clj/component/postgresql_mock.clj
@@ -3,8 +3,8 @@
             [diehard.core :as dh]
             [integrant.core :as ig]
             [pg.core :as pg]
-            [schema.core :as s]
-            [pg.migration.core :as migrations])
+            [pg.migration.core :as migrations]
+            [schema.core :as s])
   (:import (org.pg.error PGError)
            (org.testcontainers.containers PostgreSQLContainer)))
 
@@ -21,7 +21,7 @@
     (dh/with-retry {:retry-on    PGError
                     :delay-ms    2000
                     :max-retries 3}
-                   (migrations/migrate-all migrations-config))
+      (migrations/migrate-all migrations-config))
     (pg/pool postgresql-config)))
 
 (defmethod ig/halt-key! ::postgresql-mock
@@ -43,5 +43,5 @@
     (dh/with-retry {:retry-on    PGError
                     :delay-ms    2000
                     :max-retries 3}
-                   (migrations/migrate-all migrations-config))
+      (migrations/migrate-all migrations-config))
     (pg/pool postgresql-config)))

--- a/test/integration/postgresql_mock_test.clj
+++ b/test/integration/postgresql_mock_test.clj
@@ -9,7 +9,7 @@
   (:import (org.pg Pool)))
 
 (def config {::component.postgresql-mock/postgresql-mock {:components {:config {:postgresql-migrations {:migrations-table :migrations
-                                                                                                        :migrations-path  "resources/migrations"}}}}})
+                                                                                                        :migrations-path  "migrations"}}}}})
 
 (s/deftest postgresql-mock-component-test
   (let [system (ig/init config)
@@ -25,10 +25,10 @@
                :nascimento now
                :nome       "nascimento"}]
              (pg.core/with-connection [conn pool]
-                                      (pg/execute conn
-                                                  "INSERT INTO pessoa (apelido, nome, nascimento) VALUES ($1, $2, $3)
+               (pg/execute conn
+                           "INSERT INTO pessoa (apelido, nome, nascimento) VALUES ($1, $2, $3)
                                                    returning *"
-                                                  {:params ["brunão" "nascimento" now]})))))
+                           {:params ["brunão" "nascimento" now]})))))
 
     (testing "The System was stopped"
       (is (nil? (ig/halt! system))))))

--- a/test/integration/postgresql_mock_test.clj
+++ b/test/integration/postgresql_mock_test.clj
@@ -8,7 +8,8 @@
             [schema.test :as s])
   (:import (org.pg Pool)))
 
-(def config {::component.postgresql-mock/postgresql-mock {:schemas ["CREATE TABLE IF NOT EXISTS pessoa (apelido TEXT UNIQUE NOT NULL PRIMARY KEY, nome TEXT NOT NULL, nascimento DATE NOT NULL);"]}})
+(def config {::component.postgresql-mock/postgresql-mock {:components {:config {:postgresql-migrations {:migrations-table :migrations
+                                                                                                        :migrations-path  "resources/migrations"}}}}})
 
 (s/deftest postgresql-mock-component-test
   (let [system (ig/init config)
@@ -24,10 +25,10 @@
                :nascimento now
                :nome       "nascimento"}]
              (pg.core/with-connection [conn pool]
-               (pg/execute conn
-                           "INSERT INTO pessoa (apelido, nome, nascimento) VALUES ($1, $2, $3)
-                            returning *"
-                           {:params ["brunão" "nascimento" now]})))))
+                                      (pg/execute conn
+                                                  "INSERT INTO pessoa (apelido, nome, nascimento) VALUES ($1, $2, $3)
+                                                   returning *"
+                                                  {:params ["brunão" "nascimento" now]})))))
 
     (testing "The System was stopped"
       (is (nil? (ig/halt! system))))))

--- a/test/unit/common_test_clj/component/postgresql_mock_test.clj
+++ b/test/unit/common_test_clj/component/postgresql_mock_test.clj
@@ -6,5 +6,5 @@
 
 (s/deftest postgresql-pool-mock-test
   (testing "Creating a mocked PostgreSQL connection"
-    (let [conn (component.postgresql-mock/postgresql-pool-mock "resources/migrations")]
+    (let [conn (component.postgresql-mock/postgresql-pool-mock "migrations")]
       (is (= (type conn) Pool)))))

--- a/test/unit/common_test_clj/component/postgresql_mock_test.clj
+++ b/test/unit/common_test_clj/component/postgresql_mock_test.clj
@@ -6,5 +6,5 @@
 
 (s/deftest postgresql-pool-mock-test
   (testing "Creating a mocked PostgreSQL connection"
-    (let [conn (component.postgresql-mock/postgresql-pool-mock [])]
+    (let [conn (component.postgresql-mock/postgresql-pool-mock "resources/migrations")]
       (is (= (type conn) Pool)))))


### PR DESCRIPTION
### Added

- Added `pg2-migration` as a new dependency for migration support.

### Changed

- Updated PostgreSQL mock component to use migrations for database setup instead of raw schemas.
- Bumped versions of multiple dependencies to their latest releases.